### PR TITLE
LoopType に名前空間を付与

### DIFF
--- a/Assets/UnityUIPlayables/Runtime/Shared/LoopType.cs
+++ b/Assets/UnityUIPlayables/Runtime/Shared/LoopType.cs
@@ -1,6 +1,9 @@
-﻿public enum LoopType
+﻿namespace UnityUIPlayables
 {
-    Repeat,
-    Reverse,
-    PingPong
+    public enum LoopType
+    {
+        Repeat,
+        Reverse,
+        PingPong
+    }
 }


### PR DESCRIPTION
いつも利用させていただいております．

本 OSS をインストールした後に DOTween (Pro) をインストールしようとした場合に，
以下のエラーが発生していました．

```cs
Assets/Demigiant/DOTweenPro/Editor/DOTweenAnimationInspector.cs(325,22): error CS0266: Cannot implicitly convert type LoopType' toDG.Tweening.LoopType'. An explicit conversion exists (are you missing a cast?)
```

原因を探ってみると，`Assets/UnityUIPlayables/Runtime/Shared/LoopType.cs` のスクリプトに
名前空間が付与されていないことが原因であることがわかりました．

`UnityUIPlayables` 名前空間を付与したところ，こちらの問題が解決いたしました．
恐らく名前空間の付与漏れだと思われると思いますので，ご確認いただけますでしょうか．

よろしくお願いします．
